### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-run-and-push.yml
+++ b/.github/workflows/python-run-and-push.yml
@@ -1,6 +1,10 @@
 # Name of the GitHub Actions workflow
 name: Run Go Script and Push Changes
 
+# Define the permissions for the workflow
+permissions:
+  contents: write
+
 # Define the events that trigger this workflow
 on:
   # Run automatically on a schedule (daily at midnight UTC)


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/alpha6corporation-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/alpha6corporation-com-documentation/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimum permissions required for the workflow to function correctly. Since the workflow involves reading repository contents and pushing changes, the `contents` permission should be set to `write`. Other permissions should be omitted unless explicitly required.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit its scope. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
